### PR TITLE
MAINT: address type checking failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,11 @@ jobs:
         run: |
           uv run --group dev nox --force-python python -s test -- --cov-report lcov:lcov-${{matrix.os}}-${{matrix.python-version}}.lcov --cov-report term --cov-append --cov cogent3_h5seqs
 
+      - name: trust coveralls (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew trust coverallsapp/coveralls
+
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@v2
         with:

--- a/src/cogent3_h5seqs/aligned.py
+++ b/src/cogent3_h5seqs/aligned.py
@@ -187,12 +187,13 @@ class AlignedSeqsData(UnalignedSeqsData, c3_alignment.AlignedSeqsDataABC):
         **kwargs: typing.Any,  # noqa: ANN401
     ) -> AlignedSeqsData:
         data = {}
+        gap_index = typing.cast("int", alphabet.gap_index)
         for seqid, seq in seqs.items():
             gp = gaps[seqid]
             gapped = compose_gapped_seq(
-                ungapped_seq=seq,
+                ungapped_seq=alphabet.to_indices(seq),
                 gaps=gp,
-                gap_index=alphabet.gap_index,
+                gap_index=gap_index,
             )
             data[seqid] = gapped
 


### PR DESCRIPTION
[CHANGED] Route seq through alphabet.to_indices and cast gap_index
    to int, mirroring cogent3's from_seqs_and_gaps.